### PR TITLE
Fix typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@artifact-project/i18n",
   "version": "0.1.0",
-  "description": "Simple a module for internalization with support some feature CLDR.",
+  "description": "A simple module for internationalization with support some feature CLDR.",
   "author": "RubaXa <ibnRubaXa@gmail.com>",
   "license": "MIT",
   "repository": "git@github.com:artifact-project/i18n.git",


### PR DESCRIPTION
Also change `internalization` to `internationalization` in a repo description.